### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# This container will install Piggy from master
+#
+FROM debian:testing
+
+# update package metadata
+RUN apt-get update -qq
+
+# install dependancies 
+RUN apt-get install --no-install-recommends -y roary git r-cran-plyr r-cran-ggplot2 r-cran-reshape2 r-cran-xml2 libcairo2-dev build-essential
+
+# not all dependancies are packaged for apt, so install via bioconductor
+RUN Rscript -e 'source("https://bioconductor.org/biocLite.R"); biocLite(c("cowplot", "ggiraph"))'
+
+# Get the latest source code for Piggy
+RUN git clone https://github.com/harry-thorpe/piggy
+
+# Add the executables to the PATH
+ENV PATH /piggy:/piggy/bin:$PATH


### PR DESCRIPTION
I've added a Dockerfile which allows for a container containing Piggy to be built (with all dependancies). If you sign up to https://hub.docker.com/ and create an automated build pointing at your github repo, it will create a new container each time you make a change. 

To install it (assuming you signed up as harrythorpe to hub.docker.com):
```
docker pull harrythorpe/piggy
```
To use it you would use a command such as this (substituting in your directories), where your GFF files are assumed to be stored in /home/ubuntu/data:
```
docker run --rm -it -v /home/ubuntu/data:/data harrythorpe/piggy piggy -r roary_dir *.gff
```
